### PR TITLE
Prefer HTTPS and shorter urls

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -12,7 +12,7 @@ function browsehappy_get_browser_data( $browser = false ) {
 			'wikipedia' => 'Google_Chrome',
 			'normalized' => 1, // just first number
 			'facebook' => 'googlechrome',
-			'url' => 'http://www.google.com/chrome',
+			'url' => 'https://google.com/chrome/',
 			'info' => __( '&#8220;A fast new browser from Google. Try&nbsp;it&nbsp;now!&#8221;', 'browsehappy' ),
 		),
 		'firefox' => (object) array(
@@ -21,7 +21,7 @@ function browsehappy_get_browser_data( $browser = false ) {
 			'wikipedia' => 'Firefox',
 			'normalized' => 1.5, // include second number if non-zero
 			'facebook' => 'Firefox',
-			'url' => 'http://www.firefox.com/',
+			'url' => 'https://mozilla.org/firefox/',
 			'info' => __( "&#8220;Your online security is Firefox's top priority. Firefox is free, and made to help you get the most out of the&nbsp;web.&#8221;", 'browsehappy' ),
 		),
 		'safari' => (object) array(
@@ -30,7 +30,7 @@ function browsehappy_get_browser_data( $browser = false ) {
 			'wikipedia' => 'Safari',
 			'normalized' => 1.5, // include second number if non-zero
 			'facebook' => false,
-			'url' => 'http://www.apple.com/safari/',
+			'url' => 'https://www.apple.com/safari/',
 			'info' => __( '&#8220;Safari for Mac and Windows from Apple, the world’s most innovative&nbsp;browser.&#8221;', 'browsehappy' ),
 		),
 		'opera' => (object) array(
@@ -48,7 +48,7 @@ function browsehappy_get_browser_data( $browser = false ) {
 			'wikipedia' => 'Internet_Explorer',
 			'normalized' => 1, // just first number
 			'facebook' => 'internetexplorer',
-			'url' => 'http://www.microsoft.com/windows/internet-explorer/',
+			'url' => 'https://www.microsoft.com/ie',
 			'info' => __( '&#8220;Designed to help you take control of your privacy and browse with confidence. Free from&nbsp;Microsoft.&#8221;', 'browsehappy' ),
 		),
 	);


### PR DESCRIPTION
Prefer HTTPS and shorter urls

..but only when not taking extra redirects or invalid certificates.

In other words:

  "Make things as simple as possible, but not simpler."
- Google has proper HTTPS on www and non-www.
  On both www/non-www, /chrome redirects to a localised version at
  https://www.google.com/intl/LANG/chrome/browser
  This url without www is a 503 server error.
- Firefox has proper HTTPS on www and non-www.
  firefox.com and www.firefox.com have an invalid HTTPS certificate (www.mozilla.com)
  and points to a completely differrent service (something LDAP).
  On both www/non-www, /firefox redirects to a localised version at
  https://www.mozilla.org/LANG/firefox/new/
- Apple has proper HTTPS on www and non-www,
  but their non-www redirects to HTTP www.
- Opera doesn't have HTTPS. They normalise to www.
- Microsoft has proper HTTPS on www.
  HTTPS on non-www (https://microsoft.com) times out.
  On both HTTP and HTTPS, all of /windows/internet-explorer, /windows/ie
  and /ie redirect to a localised version at
  http://windows.microsoft.com/LANG/internet-explorer/download-ie
  which has an invalid HTTPS certificate (*.windows.microsoft.com)

Turns out, getting it right.. is hard.

---

Oh, and for fun, worst case scenario:

![From left to right: Google, Mozilla, Apple, Opera, Microsoft](https://f.cloud.github.com/assets/156867/210508/3e868822-8293-11e2-9a15-711618843532.png)
From left to right: Google, Mozilla, Apple, Opera, Microsoft.
