### PR TITLE
Fix Issue # 21

### DIFF
--- a/style.css
+++ b/style.css
@@ -17,6 +17,7 @@ html, body, div, span, h1, h2, p, code, em, img, ins, strong, ol, ul, li, articl
 	font-size: 100%;
 	vertical-align: baseline;
 	background: transparent;
+	-webkit-font-smoothing: antialiased;
 }
 
 article,footer,header,hgroup,menu,nav,section {


### PR DESCRIPTION
There is an issue in Safari browsers with the elements with an applied @font-face. The font-weight of said elements changes when one hovers over other elements on the page.

To reproduce the issue, simply open the page in Safari (I used Safari 8.0.1). Ensure that the footer is in view and hover over any of the “browser blocks” and you will observe the font-weights changing.

This seems to be due to Safari’s implementation of antialiasing. I have found the following to be the solution to this issue on some of my own pages in the past.

The fix involves add CSS rule to style.css.
Add "-webkit-font-smoothing: antialiased;" to CSS rule beginning on line 12.
