### PR TITLE
Removing #byline a's background-image

### DIFF
--- a/style.css
+++ b/style.css
@@ -652,7 +652,7 @@ html[dir="rtl"] #share nav li {
 @media only screen and (-webkit-min-device-pixel-ratio: 1.5),
        only screen and (min-resolution: 1.5dppx),
        only screen and (min-resolution: 144dpi) {
-	#browserlist li .icon, #share nav li a, #byline a {
+	#browserlist li .icon, #share nav li a {
 		background-image: url(imgs/browsehappy-sprite-2x.png);
 		background-repeat: no-repeat;
 		background-size: 750px 170px;


### PR DESCRIPTION
Removing the background-image from the footer's anchor links.

Screen of the issue: https://i.imgur.com/v6zS9Uq.png