### PR TITLE
fix edge version

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -123,7 +123,7 @@ function browsehappy_fetch_version( $browser, $normalize = true, $rank = true ) 
 				wikibase:rank wikibase:{$rank_type}
 			].
 		}
-		{$limit}
+		ORDER BY DESC (?version) {$limit}
 	";
 
 	$request = wp_remote_get( add_query_arg(


### PR DESCRIPTION
recently I noticed edge version is far behind current version, looks like wiki data regards both iOS, Android and PC versions as current. in this case, I would suggest adding a sorting to get the largest value.